### PR TITLE
Zero bot test

### DIFF
--- a/GuidesCog.py
+++ b/GuidesCog.py
@@ -3,8 +3,9 @@ Enables syncing guide channels with contents posted on a google spreadsheet. All
 people to collaborate on discord posts for guides.
 
 This module uses some components from other zerobot common for convenience, but everything
-related to this google drive guide syncing functionality is in here, removing this cog from
-the bot is enough to disable it completely.
+related to this google drive guide syncing functionality is in here, except for:
+- guideslog_filename in settings.json
+- adding the cog module in zerobot.py
 '''
 import zerobot_common
 from discord.ext import commands
@@ -14,8 +15,7 @@ from utilities import load_json
 
 # start log for guides module
 guides_doc = zerobot_common.drive_client.open('Discord Guides')
-guideslog_filename = 'logs/guideslog' + datetime.utcnow().strftime(zerobot_common.dateformat)
-guideslog = LogFile(guideslog_filename, zerobot_common.dateformat, zerobot_common.timeformat)
+guideslog = LogFile('logs/guideslog')
 # load config that describes which channels contain which guides
 guidechannels_filename = zerobot_common.settings.get('guidechannels_filename')
 guidechannels = load_json(guidechannels_filename)

--- a/MemberlistCog.py
+++ b/MemberlistCog.py
@@ -128,7 +128,7 @@ class MemberlistCog(commands.Cog):
     '''
     def __init__(self, bot):
         self.bot = bot
-        self.logfile = LogFile("logs/botlog_" + datetime.utcnow().strftime(zerobot_common.dateformat), zerobot_common.dateformat, zerobot_common.timeformat)
+        self.logfile = LogFile("logs/botlog")
         self.logfile.log(f'MembList cog loaded and ready.')
         self.updating = False
         self.update_msg = ""

--- a/clantrack.py
+++ b/clantrack.py
@@ -1,3 +1,13 @@
+'''
+Almost entirely self contained, need to work out:
+- code that calls updatelist (timer and command)    make new cog for tracking?
+- zerobot_common.rs_api_clan_name       only used here but ok as setting, move retrieve here
+- zerobot_common.logfile                make one here? in cog? both should work its append?
+- zerobot_common.drive_connect()        not bad, maybe utility but needs drive stuff?
+- zerobot_common.current_members_sheet  ok common use
+- zerobot_common.old_members_sheet      ok common use
+- zerobot_common.recent_changes_sheet   ok common use
+'''
 import zerobot_common
 import requests
 # for date strings
@@ -240,7 +250,7 @@ def _compareMembers(session, current_members_list, ingame_members_list, joining_
                         join.last_active = datetime.utcnow()
             # already know nobody stayed in clan with same name
             # no data to compare, leave member in to remove and continue with next.
-            zerobot_common.logfile.log(f"Missing data for leaving member : {leave.name}. Can not check for renames, member will be removed")
+            zerobot_common.logfile.log(f"Missing data for leaving member : {leave.name}. Can not check for renames")
             continue
         # calculate match chances
         best_match = 0

--- a/logfile.py
+++ b/logfile.py
@@ -1,11 +1,19 @@
 from datetime import datetime
 import os
+# uses date and time formats defined in utilities
+import utilities
 
 class LogFile:
     """
     Logfile(listbot).
     """
-    def __init__(self, filename, dateformat, timeformat):
+    def __init__(self, filename):
+        '''
+        Sets up a logfile with specified filename. Ensures directory structure
+        exists if filename uses a different folder. Current date is appended to
+        filename with a _ separator when the log is created.
+        '''
+        filename += f'_{datetime.utcnow().strftime(utilities.dateformat)}'
         # ensure directory for file exists if not creating in current directory
         dirname = os.path.dirname(filename)
         if (dirname != ''):
@@ -14,10 +22,10 @@ class LogFile:
         if (not os.path.exists(filename)):
             open(filename, 'w')
         self.filename = filename
-        self.dateformat = dateformat
-        self.timeformat = timeformat
-        self.datetimeformat = f"{dateformat} {timeformat}"
     def log(self, text):
+        '''
+        Appends text to this logfile, with 'datetime : ' prepended to it.
+        '''
         if (isinstance(text, list)):
             err_string = ''
             for errstr in text:
@@ -25,5 +33,6 @@ class LogFile:
             text = err_string
         print(text)
         file = open(self.filename, "a", encoding="utf-8")
-        file.write((datetime.utcnow().strftime(self.datetimeformat) + ' : ' + text + '\n'))
+        timestamp = datetime.utcnow().strftime(utilities.datetimeformat)
+        file.write((timestamp + ' : ' + text + '\n'))
         file.close()

--- a/site_ops.py
+++ b/site_ops.py
@@ -54,13 +54,13 @@ class SiteOps:
     """
     Clan site account operations.
     """
-    def __init__(self, dateformat, timeformat):
+    def __init__(self):
         """
         New object for site access operations
         - logfile = logfile object from bot for logging / debugging
         """
         self.session = requests.session()
-        self.logfile = LogFile("logs/sitelog_" + datetime.utcnow().strftime(dateformat), dateformat, timeformat)
+        self.logfile = LogFile("logs/sitelog")
         self.logfile.log(f'New log started for site operations.')
 
         self.token = None

--- a/utilities.py
+++ b/utilities.py
@@ -1,6 +1,10 @@
 import json
 import os
 
+dateformat = '%Y-%m-%d'
+timeformat = '%H:%M:%S'
+datetimeformat = '%Y-%m-%d %H:%M:%S'
+
 def load_json(filename):
     '''
     Wrapper function to load json from filename. Creates file and loads a blank json dictionary if it does not exist.

--- a/zerobot_common.py
+++ b/zerobot_common.py
@@ -1,22 +1,33 @@
 # variables, functions and settings that are shared between zerobot modules
 
-# MAKE SURE YOU DO NOT SHARE your bot auth_token or drive creds keyfile, anyone can use them to 
-# modify your drive docs or take over your bot and do anything it has permissions for.
-# if you use git, the credentials folder used for these files in settings.json is in the .gitignore.
+# MAKE SURE YOU DO NOT SHARE your bot auth_token or drive creds keyfile, anyone
+# can use them to modify your drive docs or take over your bot and do anything 
+# it has permissions for. if you use git, the credentials folder used for these
+# files in settings.json is in the .gitignore.
 
-# WARNING: Everything in here should be referenced directly and fully as zerobot_common.something
-# Do not make local copies of them for reference, or be EXTREMELY sure they are NEVER reassigned.
-# if in a different file you do, for example : _easy_name = zerobot_common.discord_roles_filename
-# that copy will point to the same object initially, but if the one in here is ever reassigned your
-# copy will not update and will still point to the old value, not the new one! similarly, reassigning
-# your copy afterwards : _easy_name = new value will NOT update zerobot_common.discord_roles_filename
+# WARNING: Everything in here should be referenced directly and fully as 
+# zerobot_common.something. Do not make local copies of them for reference, or 
+# be EXTREMELY sure they are NEVER reassigned. For example, if you use in a 
+# different file : _easy_name = zerobot_common.variable, that copy will point 
+# to the same object initially, but if the one in here is ever reassigned your
+# copy will not update and will still point to the old value, not the new one! 
+# similarly, reassigning your copy afterwards : _easy_name = new_value, will 
+# NOT update zerobot_common.discord_roles_filename
 
-# Note on circular dependencies:
-# This file imports the init constructors from Applications, SiteOps, Permissions.
-# But those files also require certain imports from this file.
-# This works as long as the program start is not in either of these and imports zerobot_common.
-# I prefer this over splitting this file, it also makes sense from an order of operations view,
-# the references required should all be established by the time the constructors are called.
+# Note on imports and circular dependencies:
+# This module should not have circular depencies, it should be self contained 
+# and decoupled from other files as much as possible.
+# - utilities, logfile, applications modules are safe, self contained imports.
+#
+# site_ops and permissions modules break this promise, they require references 
+# to this module. However, they only use references to this module in functions
+# that are not run at import time.
+# So while they are linked, they do not cause circular dependencies for imports
+# and as long as the program ensures that those references have been 
+# initialised by the time those functions are run (which it does) there is no
+# problem with imports at program runtime. I currently prefer this over
+# splitting this file, and it makes sense from an order of operations view. But
+# I might look into decoupling them a bit more in the future.
 
 import json
 import os
@@ -25,6 +36,7 @@ from datetime import datetime
 import gspread
 from oauth2client.service_account import ServiceAccountCredentials
 # zerobot modules
+import utilities
 from utilities import load_json, dump_json
 from logfile import LogFile
 from applications import Applications
@@ -35,29 +47,35 @@ from permissions import Permissions
 settings_file = 'settings.json'
 settings = load_json(settings_file)
 
-# load authentication token for starting bot, you should have made your own for your new discord bot.
-# starting point to create a discord application (bot) : https://discord.com/developers/applications
+# load authentication token for starting bot, you should have made your own 
+# discord bot. Create a discord application, then make a bot for it. Starting
+# point to do that is here: https://discord.com/developers/applications
 bot_auth_token_filename = settings.get('bot_auth_token_filename')
 auth_file = open(bot_auth_token_filename)
 auth_token = auth_file.read()
 auth_file.close()
 
 # Google Drive credentials and client to interact with the Google Drive API
-# you should have created service account credentials to access your google sheets document.
-# starting point to create google web credentials : https://console.developers.google.com/
+# You should have a service account, with credentials to login to it.
+# Starting point for creating one : https://console.developers.google.com/
+# You should also have given your service account access to your drive sheet:
+# Invite it using the share button on the doc, use the service account's email.
 drive_scope = ['https://spreadsheets.google.com/feeds',
         'https://www.googleapis.com/auth/drive']
 drive_creds_keyfile_name = settings.get('drive_creds_keyfile_name')
-drive_creds = ServiceAccountCredentials.from_json_keyfile_name(drive_creds_keyfile_name, drive_scope)
+drive_creds = ServiceAccountCredentials.from_json_keyfile_name(
+    drive_creds_keyfile_name,
+    drive_scope
+)
 drive_client = gspread.authorize(drive_creds)
 drive_doc_name = settings.get('drive_doc_name')
 drive_doc = drive_client.open(drive_doc_name)
 
 # spreadsheet tabs that are used
-current_members_sheet = drive_doc.worksheet("Current Members")
-old_members_sheet = drive_doc.worksheet("Old Members")
-banned_members_sheet = drive_doc.worksheet("Banned Members")
-recent_changes_sheet = drive_doc.worksheet("Recent Changes")
+current_members_sheet = drive_doc.worksheet('Current Members')
+old_members_sheet = drive_doc.worksheet('Old Members')
+banned_members_sheet = drive_doc.worksheet('Banned Members')
+recent_changes_sheet = drive_doc.worksheet('Recent Changes')
 
 def drive_connect():
     '''
@@ -65,27 +83,31 @@ def drive_connect():
     '''
     if (drive_creds.access_token_expired): drive_client.login()
 
-# date and time formats
-dateformat = settings.get('dateformat')
-timeformat = settings.get('timeformat')
+# if set, use date and time formats from settings 
+dateformat = settings.get('dateformat', utilities.dateformat)
+timeformat = settings.get('timeformat', utilities.dateformat)
+utilities.dateformat = dateformat
+utilities.timeformat = timeformat
+utilities.datetimeformat = dateformat + ' ' + timeformat
 
-# Manager for operations to a clan website, hosted by shivtr (https://shivtr.com/)
-site_login_credentials_filename = settings.get('site_login_credentials_filename')
-site_login_credentials = load_json(site_login_credentials_filename)
+# Manager for operations to clan site, hosted by shivtr (https://shivtr.com/)
+site_login_creds_filename = settings.get('site_login_credentials_filename')
+site_login_credentials = load_json(site_login_creds_filename)
 site_base_url = settings.get('site_base_url')
-siteops = SiteOps(dateformat, timeformat)
-# disable site component? (site rank functions will always have 'full member' as result)
+siteops = SiteOps()
+# disable site? (site rank functions will always have 'full member' as result)
 site_disabled = settings.get('site_disabled')
 
 # name used to look up members_lite clan memberlist file on official rs api
 rs_api_clan_name = settings.get('rs_api_clan_name')
-# guild = the clan discord 'server' object, loaded on bot startup using it's id.
+# guild = the clan discord 'server' object, loaded on bot start using it's id.
 clan_server_id = settings.get('clan_server_id')
 guild = None
 
-# category that new application channels should be added under, loaded on bot startup from guild.
+# category new application channels should be added under, loaded on bot start 
+# from guild object.
 applications_category_id = settings.get('applications_category_id')
-# channel that allows application commands, this channel also gets cleared automatically
+# channel that allows application commands and gets cleared typing after them.
 app_requests_channel_id = settings.get('app_requests_channel_id')
 applications_category = None
 
@@ -98,9 +120,9 @@ discord_roles = None
 default_bot_channel_id = settings.get('default_bot_channel_id')
 
 # logfiles
-logfile = LogFile("logs/logfile_" + datetime.utcnow().strftime(dateformat), dateformat, timeformat)
-reactionlog = LogFile("logs/reactionroles_" + datetime.utcnow().strftime(dateformat), dateformat, timeformat)
-applications_log = LogFile("logs/applications_" + datetime.utcnow().strftime(dateformat), dateformat, timeformat)
+logfile = LogFile('logs/logfile')
+reactionlog = LogFile('logs/reactionroles')
+applications_log = LogFile('logs/applications')
 
 # load known messages that should give a role for a reaction from disk
 reaction_messages_filename = settings.get('reaction_messages_filename')
@@ -116,4 +138,5 @@ permissions = Permissions(permissions_filename)
 
 # people that wont be shown on the inactives list
 inactive_exceptions_filename = settings.get('inactive_exceptions_filename')
-inactive_exceptions = load_json(inactive_exceptions_filename).get('inactive_exceptions')
+json_dictionary = load_json(inactive_exceptions_filename)
+inactive_exceptions = json_dictionary.get('inactive_exceptions')


### PR DESCRIPTION
Move datetime format definitions to utilities module
- can be overridden with settings.json through zerobot_common
- simplify log creation, use timestamp format from utilities
- still need to remove some zerobot_common.datetime references in other files (non-breaking)
- start using max line width = 80 for easier side by side work, applied to zerobot_common